### PR TITLE
Update README with Debian installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,9 @@ uv tool install niri-companion
 ```
 
 For Arch-based distributions, you can use the [`niri-companion`](https://aur.archlinux.org/packages/niri-companion) AUR package
+
+For Debian-based distributions, you can use the [`niri-companion`](https://tracker.debian.org/pkg/niri-companion) package (Available in Debian 14 and Above)
+
+```sh
+sudo apt install niri-companion
+```


### PR DESCRIPTION
Added installation instructions for Debian-based distributions.

niri-companion is now available in Debian Sid and will be available in Debian 14 in a few days and will be included in the next debian release